### PR TITLE
Add Composer 2 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,9 @@
         "class": "Mautic\\Composer\\InstallerPlugin"
     },
     "require": {
-        "composer-plugin-api": "^1.0"
+        "composer-plugin-api": "^1.0 || ^2.0"
     },
     "require-dev": {
-        "composer/composer": "^1.5"
+        "composer/composer": "^1.5 || ^2.0"
     }
 }

--- a/src/InstallerPlugin.php
+++ b/src/InstallerPlugin.php
@@ -19,6 +19,16 @@ class InstallerPlugin implements PluginInterface, EventSubscriberInterface
         $composer->getInstallationManager()->addInstaller($installer);
     }
 
+    public function deactivate(Composer $composer, IOInterface $io)
+    {
+        // Method must exist for composer-plugin-api 2 support
+    }
+
+    public function uninstall(Composer $composer, IOInterface $io)
+    {
+        // Method must exist for composer-plugin-api 2 support
+    }
+
     public static function getSubscribedEvents()
     {
         return [


### PR DESCRIPTION
https://blog.packagist.com/deprecating-composer-1-support/

Composer 1 is now throwing warnings about being deprecated.

This PR adds support for Composer 2:

* Backwards compatible with v1 due to the `composer-plugin-api` version constraint.
* Add the missing methods required for v2 support (they're subs as it appears nothing needs to be done on uninstall or deactivate of this plugin)

As such this should work for both Composer v1 and v2 without any noticeable changes.